### PR TITLE
Links reports to the editor

### DIFF
--- a/src/app/editor/components/Card.vue
+++ b/src/app/editor/components/Card.vue
@@ -2,10 +2,12 @@
     <div>
         <div class="card-container"><span class="card-label">{{nodegroup.card.name}}</span>
         <div class="card-container" v-for="tile in nodegroup.card.tiles">
+            <div class="done-btn" @touchstart="toeditor(nodegroup.card, tile)">
             <component v-for="widget in tile.widgets" :allNodes="allNodes" class="widget" :context="'report'" :tile="tile" :widget="widget" v-bind:is="'base-widget'"></component>
+            </div>
         </div>
         <div v-for="nodegroup in nodegroup.children">
-            <card :nodegroup="nodegroup" class="report-content"></card>
+            <card :nodegroup="nodegroup" class="report-content" v-on:switch-tabs="updateActiveIndex"></card>
         </div>
         </div>
     </div>
@@ -13,7 +15,7 @@
 
 <script>
 export default {
-    name: 'ResourceReportPage',
+    name: 'Card',
     props: ['nodegroup'],
     data() {
         return {
@@ -21,7 +23,24 @@ export default {
             user: this.$store.getters.activeServer.user
         };
     },
+    methods: {
+        updateActiveIndex: function(event) {
+            this.$emit('switch-tabs', 1);
+        },
+        toeditor: function(card, tile) {
+            this.$store.getters.activeServer.card_nav_stack.unshift({card: card, tile: tile, showForm: true, activeObject: 'tile', 'tabIndex': 1});
+            this.$emit('switch-tabs', 1);
+        }
+    },
     computed: {
+        tabIndex: {
+            get: function() {
+                return this.activeIndex;
+            },
+            set: function(val) {
+                this.activeIndex = val;
+            }
+        },
         tiles: {
             get: function() {
                 return this.$store.getters.tiles;

--- a/src/app/editor/components/Card.vue
+++ b/src/app/editor/components/Card.vue
@@ -1,10 +1,13 @@
 <template>
     <div>
         <div class="card-container"><span class="card-label">{{nodegroup.card.name}}</span>
-        <div class="card-container" v-for="tile in nodegroup.card.tiles">
+        <div class="card-container" v-if="nodegroup.card.tiles.length > 0" v-for="tile in nodegroup.card.tiles">
             <div class="done-btn" @touchstart="toeditor(nodegroup.card, tile)">
-            <component v-for="widget in tile.widgets" :allNodes="allNodes" class="widget" :context="'report'" :tile="tile" :widget="widget" v-bind:is="'base-widget'"></component>
+                <component v-for="widget in tile.widgets" :allNodes="allNodes" class="widget" :context="'report'" :tile="tile" :widget="widget" v-bind:is="'base-widget'"></component>
             </div>
+        </div>
+        <div class="card-container" v-if="nodegroup.card.tiles.length == 0">
+            <div>None</div>
         </div>
         <div v-for="nodegroup in nodegroup.children">
             <card :nodegroup="nodegroup" class="report-content" v-on:switch-tabs="updateActiveIndex"></card>

--- a/src/app/editor/components/ResourcePage.vue
+++ b/src/app/editor/components/ResourcePage.vue
@@ -15,9 +15,9 @@
             </v-ons-toolbar>
             <v-ons-splitter>
                 <v-ons-splitter-content>
-                    <v-ons-tabbar swipeable animation="none" :index.sync="activeIndex">
+                    <v-ons-tabbar swipeable animation="none" :index.sync="activeindex">
                       <template slot="pages">
-                          <resource-report-page :project="project" :activeindex="activeIndex"></resource-report-page>
+                          <resource-report-page :project="project" :activeindex="activeindex" v-on:switch-tabs="updateActiveIndex"></resource-report-page>
                           <resource-edit-page v-on:saving="saving = $event" :goBack="goBack"/>
                       </template>
 
@@ -39,7 +39,7 @@ export default {
     data() {
         return {
             goBack: false,
-            activeIndex: 1,
+            activeindex: 0,
             saving: false,
             project: this.$store.getters.activeProject,
             tabs: [
@@ -74,10 +74,12 @@ export default {
     methods: {
         back: function() {
             this.goBack = !this.goBack;
+        },
+        updateActiveIndex: function(event) {
+            this.activeindex = event;
         }
     },
     created: function() {
-        console.log('beforeCreate');
         if (!!this.$store.getters.activeServer) {
             this.$store.getters.activeServer.card_nav_stack = [];
             this.$store.getters.activeServer.card_nav_stack.unshift({card: null, tile: null, showForm: false, activeObject: 'tile', 'tabIndex': this.tabIndex});

--- a/src/app/editor/components/ResourceReportPage.vue
+++ b/src/app/editor/components/ResourceReportPage.vue
@@ -1,7 +1,7 @@
 <template>
     <v-ons-page>
       <div v-for="nodegroup in cardTree">
-          <card :nodegroup="nodegroup" class="report-content"></card>
+          <card :nodegroup="nodegroup" class="report-content" :activeindex="activeindex" v-on:switch-tabs="updateActiveIndex"></card>
       </div>
     </v-ons-page>
 </template>
@@ -18,6 +18,11 @@ export default {
             resourceid: this.$store.getters.activeServer.active_resource,
             user: this.$store.getters.activeServer.user,
         };
+    },
+    methods: {
+        updateActiveIndex: function(event) {
+            this.$emit('switch-tabs', 1);
+        }
     },
     watch: {
         activeindex: function(val, oldVal) {


### PR DESCRIPTION
Links a tile in a report to it's form in the editor. Makes the report the default page for a resource instance and indicates `None` if a card has no tiles in a report. re #133